### PR TITLE
fix type conflict issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ parser.add_argument('--epoch', dest='epoch', type=int, default=100, help='number
 parser.add_argument('--batch_size', dest='batch_size', type=int, default=16, help='number of samples in one batch')
 parser.add_argument('--patch_size', dest='patch_size', type=int, default=48, help='patch size')
 parser.add_argument('--start_lr', dest='start_lr', type=float, default=0.001, help='initial learning rate for adam')
-parser.add_argument('--eval_every_epoch', dest='eval_every_epoch', default=20, help='evaluating and saving checkpoints every #  epoch')
+parser.add_argument('--eval_every_epoch', dest='eval_every_epoch', type=int, default=20, help='evaluating and saving checkpoints every #  epoch')
 parser.add_argument('--checkpoint_dir', dest='ckpt_dir', default='./checkpoint', help='directory for checkpoints')
 parser.add_argument('--sample_dir', dest='sample_dir', default='./sample', help='directory for evaluating outputs')
 


### PR DESCRIPTION
In the origianl version(on Dec.2nd, 2020), conflict type issue is poped up, which results from `line23` in `main.py`.
This issue can be solved by fixing argument parser(assignning a definated type to `eval_every_epoch`).
Moreover, this issue is solved in another pull request [#12](https://github.com/weichen582/RetinexNet/pull/12). Anyway, the solution in my request is more effecient and completed(only in my point of view).
In my branch, this issue is fixed, and hope authors can merge my branch to the master if it is useful.